### PR TITLE
Add cluster_id and url entity

### DIFF
--- a/app.py
+++ b/app.py
@@ -133,6 +133,8 @@ def sync_clusters(entities, cluster_registry_url, access_token):
             continue
         entity = {}
         entity['id'] = '{}[kubernetes-cluster]'.format(cluster['id'])
+        entity['cluster_id'] = cluster['id']
+        entity['url'] = cluster['api_server_url']
         for key in keys_to_map:
             entity[key] = str(cluster[key])
         entity['type'] = 'kubernetes_cluster'


### PR DESCRIPTION
This adds `cluster_id` and `url` entities to the `kubernetes_cluster`
entity type.

* `cluster_id` is to make it simpler to make checks based on the
  cluster id (the normal `id` value is replaced by the zmon entity id
  with the `[kubernetes_cluster]` suffix)
* `url` is the same as `api_server_url` but makes it possible for ZMON
  to automatically find the url when using the `http()` function.